### PR TITLE
Add CLI prototype

### DIFF
--- a/bids2table/cli.py
+++ b/bids2table/cli.py
@@ -1,0 +1,56 @@
+import argparse
+from pathlib import Path
+
+import elbow.utils
+
+from .loaders import load_bids_parquet
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-i", "--input",
+        type=Path,
+        help="Path to BIDS dataset",
+        required=True
+    )
+    parser.add_argument(
+        "-o", "--output",
+        type=Path,
+        help="Path to output parquet dataset directory",
+        required=True
+    )
+    parser.add_argument(
+        "-u", "--update",
+        help="update dataset incrementally with only new or changed files.",
+        action="store_true"
+    )
+    parser.add_argument(
+        "-c", "--cores",
+        type=int,
+        help="number of parallel processes. If `None` or 1, run in the main"
+             "process. Setting to -1 runs in `os.cpu_count()` processes.",
+        default=None
+    )
+    parser.add_argument(
+        "-s", "--suppress_warnings",
+        help="suppress warnings",
+        action="store_true"
+    )
+
+    args = parser.parse_args()
+
+    if args.suppress_warnings:
+        elbow.utils.setup_logging("ERROR")
+
+    load_bids_parquet(
+        path=args.input,
+        where=args.output,
+        incremental=args.update,
+        workers=args.cores
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/bids2table/cli.py
+++ b/bids2table/cli.py
@@ -10,47 +10,45 @@ def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        "-i", "--input",
-        type=Path,
-        help="Path to BIDS dataset",
-        required=True
+        "-i", "--input", type=Path, help="Path to BIDS dataset.", required=True
     )
     parser.add_argument(
-        "-o", "--output",
+        "-o",
+        "--output",
         type=Path,
         help="Path to output parquet dataset directory",
-        required=True
+        required=True,
     )
     parser.add_argument(
-        "-u", "--update",
-        help="update dataset incrementally with only new or changed files.",
-        action="store_true"
+        "-u",
+        "--incremental",
+        help="Update dataset incrementally with only new or changed files.",
+        action="store_true",
     )
     parser.add_argument(
-        "-c", "--cores",
+        "-w",
+        "--workers",
         type=int,
-        help="number of parallel processes. If `None` or 1, run in the main"
-             "process. Setting to -1 runs in `os.cpu_count()` processes.",
-        default=None
+        help="Number of parallel processes. If `None` or 1, run in the main"
+        "process. Setting to -1 runs in `os.cpu_count()` processes.",
+        default=None,
     )
     parser.add_argument(
-        "-s", "--suppress_warnings",
-        help="suppress warnings",
-        action="store_true"
+        "-v", "--verbose", help="Verbose logging.", action="store_true"
     )
 
     args = parser.parse_args()
 
-    if args.suppress_warnings:
+    if not args.verbose:
         elbow.utils.setup_logging("ERROR")
 
     load_bids_parquet(
         path=args.input,
         where=args.output,
-        incremental=args.update,
-        workers=args.cores
+        incremental=args.incremental,
+        workers=args.workers,
     )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
 [flake8]
 ignore = E501,E203,E266,W503,E741
 max-line-length = 88
+
+[options.entry_points]
+console_scripts =
+    b2t = bids2table.cli:main


### PR DESCRIPTION
Adds a minimal CLI. Entrypoint gets registred when the package is pip installed.

```sh
$ b2t
usage: b2t [-h] -i INPUT -o OUTPUT [-u] [-c CORES] [-s]
b2t: error: the following arguments are required: -i/--input, -o/--output

$ b2t --help
usage: b2t [-h] -i INPUT -o OUTPUT [-u] [-c CORES] [-s]

options:
  -h, --help            show this help message and exit
  -i INPUT, --input INPUT
                        Path to BIDS dataset
  -o OUTPUT, --output OUTPUT
                        Path to output parquet dataset directory
  -u, --update          update dataset incrementally with only new or changed files.
  -c CORES, --cores CORES
                        number of parallel processes. If `None` or 1, run in the mainprocess. Setting to -1 runs in `os.cpu_count()` processes.
  -s, --suppress_warnings
                        suppress warnings

$ b2t -i my/bids/dir -o test_run -s
689it [00:02, 320.37it/s, tot=689, good=689, rec=333, err=0]
```