### PR TITLE
Fix handling of extra entities

### DIFF
--- a/bids2table/extractors/entities.py
+++ b/bids2table/extractors/entities.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from dataclasses import asdict, dataclass, field, fields
 from functools import lru_cache
 from pathlib import Path
@@ -96,7 +97,7 @@ class BIDSEntities:
     )
     suffix: Optional[str] = bids_field(name="Suffix")
     ext: Optional[str] = bids_field(name="Extension")
-    extra_entities: Optional[Dict[str, Union[str, int, float]]] = bids_field(
+    extra_entities: Optional[Dict[str, Union[str, int]]] = bids_field(
         name="Extra entities",
         default_factory=dict,
     )
@@ -107,7 +108,7 @@ class BIDSEntities:
         Initialize from a dict of entities.
         """
         filtered = {}
-        extra_entities: Dict[str, Union[str, int, float]] = {}
+        extra_entities: Dict[str, Union[str, int]] = {}
         fields_map = {f.name: f for f in fields(cls) if f.name != "extra_entities"}
 
         def add_to_extra(k: Any, v: Any):
@@ -115,12 +116,13 @@ class BIDSEntities:
                 raise TypeError(
                     f"Extra entity {k} has type {type(k)}; only str supported"
                 )
-            if not isinstance(v, (str, int, float)):
-                raise TypeError(
+            if isinstance(v, (str, int)):
+                extra_entities[k] = v
+            else:
+                warnings.warn(
                     f"Value {v} for extra entity {k} has type {type(v)}; "
-                    f"only str, int, float supported"
+                    f"only str, int supported"
                 )
-            extra_entities[k] = v
 
         for key, val in entities.items():
             if pd.isna(val):

--- a/bids2table/extractors/entities.py
+++ b/bids2table/extractors/entities.py
@@ -102,7 +102,7 @@ class BIDSEntities:
     )
 
     @classmethod
-    def from_dict(cls, entities: Dict[str, Any]):
+    def from_dict(cls, entities: Dict[str, Any], valid_only: bool = False):
         """
         Initialize from a dict of entities.
         """
@@ -155,7 +155,7 @@ class BIDSEntities:
                 for k, v in val.items():
                     add_to_extra(k, v)
 
-            else:
+            elif not valid_only:
                 add_to_extra(key, val)
 
         return cls(**filtered, extra_entities=extra_entities)
@@ -182,7 +182,7 @@ class BIDSEntities:
         self,
         prefix: Optional[StrOrPath] = None,
         valid_only: bool = False,
-        int_format: str = "%02d",
+        int_format: str = "%d",
     ) -> Path:
         """
         Generate a filepath based on the entitities.
@@ -248,7 +248,7 @@ def _fmt_ent(
     k: str,
     v: Union[str, int],
     *,
-    int_format: str = "%02d",
+    int_format: str = "%d",
 ):
     if isinstance(v, int):
         v = int_format % v

--- a/bids2table/helpers.py
+++ b/bids2table/helpers.py
@@ -20,10 +20,13 @@ def join_bids_path(
         df = pd.read_parquet("dataset.parquet")
         paths = df.apply(join_bids_path, axis=1)
     """
+    if "entities" in row:
+        row = row["entities"]
+
     if isinstance(row, pd.Series):
         row = row.to_dict()
 
-    entities = BIDSEntities.from_dict(row)
+    entities = BIDSEntities.from_dict(row, valid_only=valid_only)
     path = entities.to_path(prefix=prefix, valid_only=valid_only)
     return path
 

--- a/tests/test_extractors/test_entities.py
+++ b/tests/test_extractors/test_entities.py
@@ -10,12 +10,12 @@ from bids2table.extractors.entities import BIDSEntities, parse_bids_entities
 
 EXAMPLES = (
     (
-        "dataset/sub-A01/ses-B02/func/sub-A01_ses-B02_task-rest_run-01_bold.nii",
+        "dataset/sub-A01/ses-B02/func/sub-A01_ses-B02_task-rest_run-1_bold.nii",
         {
             "sub": "A01",
             "ses": "B02",
             "task": "rest",
-            "run": "01",
+            "run": "1",
             "datatype": "func",
             "suffix": "bold",
             "ext": ".nii",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,93 @@
+from typing import Any, Dict, Optional
+
+import pandas as pd
+import pytest
+
+from bids2table.helpers import join_bids_path
+
+
+@pytest.mark.parametrize(
+    "row,prefix,valid_only,expected",
+    [
+        (
+            {"sub": "A01", "ses": "b", "run": 2, "suffix": "bold", "ext": ".json"},
+            None,
+            False,
+            "sub-A01/ses-b/sub-A01_ses-b_run-2_bold.json",
+        ),
+        (
+            {"sub": "A01", "ses": "b", "run": 2, "suffix": "bold", "ext": ".json"},
+            "dataset",
+            False,
+            "dataset/sub-A01/ses-b/sub-A01_ses-b_run-2_bold.json",
+        ),
+        (
+            {
+                "sub": "A01",
+                "ses": "b",
+                "run": 2,
+                "extraKey": 1,
+                "suffix": "bold",
+                "ext": ".json",
+            },
+            None,
+            False,
+            "sub-A01/ses-b/sub-A01_ses-b_run-2_extraKey-1_bold.json",
+        ),
+        (
+            {
+                "sub": "A01",
+                "ses": "b",
+                "run": 2,
+                "extraKey": 1,
+                "suffix": "bold",
+                "ext": ".json",
+            },
+            None,
+            True,
+            "sub-A01/ses-b/sub-A01_ses-b_run-2_bold.json",
+        ),
+        (
+            {
+                "entities": {
+                    "sub": "A01",
+                    "ses": "b",
+                    "run": 2,
+                    "suffix": "bold",
+                    "ext": ".json",
+                }
+            },
+            None,
+            False,
+            "sub-A01/ses-b/sub-A01_ses-b_run-2_bold.json",
+        ),
+        (
+            pd.concat(
+                [
+                    pd.Series(
+                        {
+                            "sub": "A01",
+                            "ses": "b",
+                            "run": 2,
+                            "suffix": "bold",
+                            "ext": ".json",
+                        }
+                    )
+                ],
+                keys=["entities"],
+            ),
+            None,
+            False,
+            "sub-A01/ses-b/sub-A01_ses-b_run-2_bold.json",
+        ),
+    ],
+)
+def test_join_bids_path(
+    row: Dict[str, Any], prefix: Optional[str], valid_only: bool, expected: str
+):
+    path = join_bids_path(row, prefix=prefix, valid_only=valid_only)
+    assert str(path) == expected
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
@nx10 was encountering some errors when trying to reconstruct BIDS file paths from dataframe rows that contained extra fields. Here we introduce a few changes to fix that:

- Calling `join_bids_path()` with `valid_only=True` should ignore all unsupported BIDS entities.
- `join_bids_path()` now extracts the `entities` column group is present. This way, `join_bids_path()` can be applied to the full dataframe without issue.
- Warn but don't raise an exception for extra entities with unsupported types (i.e. anything other than `str`, `int`).